### PR TITLE
fix watcher in vagrant vm's

### DIFF
--- a/gulp/tasks/watch/default.js
+++ b/gulp/tasks/watch/default.js
@@ -40,7 +40,9 @@ var watchTask = function () {
     }
 
     if (task) {
-      watch(task.src, function () {
+      watch(task.src, {
+        usePolling: true,
+      }, function () {
         require('../' + taskName.replace(':', '/'))()
       })
     }


### PR DESCRIPTION
gulp-watch passes `usePolling` to chokidar so that the watching in nfs environments is working

fixes #9 
