### PR TITLE
show error if user config parsing failes

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -84,7 +84,7 @@ var config = function (opts) {
     runConfig = _.merge(runConfig, userConfig)
     gutil.log('User config loaded!')
   } catch (e) {
-    gutil.log('No user config found!')
+    gutil.log('Error parsing user config: ', e.message)
   }
 
   gutil.log('Run on ' + isBuild ? 'production' : 'development' + ' config.')


### PR DESCRIPTION
if the user config fails to parse (for example because of a syntax error), craffft shows an error that the user config does not exist. with this pull request, the real error is shown (either it does not exist or that there is a syntax error).
